### PR TITLE
Allow cross-origin requests from browsers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ configurations {
 
 dependencies {
     compile 'org.eclipse.jetty:jetty-servlet:9.3.5.v20151012'
+    compile 'org.eclipse.jetty:jetty-servlets:9.3.5.v20151012'
     compile 'javax.servlet:javax.servlet-api:3.1.0'
 
     compile 'org.glassfish.jersey.containers:jersey-container-jetty-servlet:2.22.1'

--- a/src/main/java/org/terasology/web/JettyMain.java
+++ b/src/main/java/org/terasology/web/JettyMain.java
@@ -19,14 +19,17 @@ package org.terasology.web;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.EnumSet;
 import java.util.Locale;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.mvc.freemarker.FreemarkerMvcFeature;
 import org.glassfish.jersey.servlet.ServletContainer;
@@ -47,6 +50,8 @@ import org.terasology.web.servlet.ServerServlet;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+
+import javax.servlet.DispatcherType;
 
 
 /**
@@ -176,6 +181,9 @@ public final class JettyMain {
         jerseyContext.setContextPath("/");
         jerseyContext.setResourceBase("templates");
         jerseyContext.addServlet(new ServletHolder(new ServletContainer(rc)), "/*");
+
+        FilterHolder holder = new FilterHolder(new CrossOriginFilter());
+        jerseyContext.addFilter(holder, "/*", EnumSet.of(DispatcherType.REQUEST));
 
         HandlerList handlers = new HandlerList();
         handlers.addHandler(logContext);


### PR DESCRIPTION
This allows browsers to access the metadata API (e.g. `/modules/list/latest`) using XMLHttpRequest, as mentioned in MovingBlocks/FacadeServer#4.